### PR TITLE
fix invalid `nm` value

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -828,7 +828,7 @@ function addShape(shapesArray, element, topLevel)
         return;
     }
     let id = element.getProperty("id");
-    shape.nm = (!topLevel ? id : false) ?? "Object";
+    shape.nm = (!topLevel ? id : null) ?? "Object";
     if (id !== null && id !== "" && !topLevel) {
         shape.ln = id.replace(/ /g, '-');
     }


### PR DESCRIPTION
Exporting with files with `nm=false` breaks lottie-react-native. This previously worked in 1.8.0 but was broken in the following release via https://github.com/Pixofield/keyshape-lottie-format/commit/727206813662d60427e4baa91c72150768882807#diff-54a9baa88b5b78ba682102145d51e90d5a8ee107fc7b0e98a54028967d219c78R831